### PR TITLE
Fixes crashes when there are more consumers than partitions

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -125,7 +125,7 @@ module Kafka
         # run the same algorithm on the same sorted lists of instances and partitions,
         # all instances should be in agreement of the distribtion.
         distributed_partitions = self.class.distribute_partitions(running_instances, partitions)
-        my_partitions = distributed_partitions[@instance]
+        my_partitions = distributed_partitions.fetch(@instance, [])
 
         logger.info "Claiming #{my_partitions.length} out of #{partitions.length} partitions."
 


### PR DESCRIPTION
Obviously, this isn't a great situation to be in, but we shouldn't just fall over when it happens; it should be handled gracefully.